### PR TITLE
Update GitHub Ribbons image url

### DIFF
--- a/bw_sphinxtheme/themes/bw/layout.html
+++ b/bw_sphinxtheme/themes/bw/layout.html
@@ -156,7 +156,7 @@
   </head>
   <body>
     {% if theme_github_ribbon %}
-    <a href="{{ theme_github_ribbon_link }}"><img style="position: absolute; top: 0; left: 0; border: 0;" src="https://a248.e.akamai.net/assets.github.com/img/bec6c51521dcc8148146135149fe06a9cc737577/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub"></a>
+    <a href="{{ theme_github_ribbon_link }}"><img style="position: absolute; top: 0; left: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
     {% endif %}
     <div class="wrapper">
       {%- block header %}{% endblock %}


### PR DESCRIPTION
The previous url is not available anymore, so I updated it to the new url (according [their blog post](https://github.com/blog/273-github-ribbons).)
