### PR TITLE
Support the recent Sphinx versions

### DIFF
--- a/bw_sphinxtheme/themes/bw/genindex.html
+++ b/bw_sphinxtheme/themes/bw/genindex.html
@@ -46,11 +46,11 @@
 <table style="width: 100%" class="indextable genindextable"><tr>
   {%- for column in entries|slice(2) if column %}
   <td style="width: 33%" valign="top"><dl>
-    {%- for entryname, (links, subitems) in column %}
-      {{ indexentries(entryname, links) }}
-      {%- if subitems %}
+    {%- for entryname, entry in column %}
+      {{ indexentries(entryname, entry[0]) }}
+      {%- if entry[1] %}
       <dd><dl>
-      {%- for subentryname, subentrylinks in subitems %}
+      {%- for subentryname, subentrylinks in entry[1] %}
         {{ indexentries(subentryname, subentrylinks) }}
       {%- endfor %}
       </dl></dd>


### PR DESCRIPTION
The recent Sphinx versions provide triples instead of pairs.  To make it compatible with both previous versions and recent versions, tuple unpacking need to be replaced by tuple indexing.
